### PR TITLE
Added new words that end with $ to helpify for hover help lookups.

### DIFF
--- a/src/TokenInfo.ts
+++ b/src/TokenInfo.ts
@@ -164,6 +164,74 @@ export class TokenInfo {
 			word = "DO...LOOP"
 		} else if (word == "declare" || (word == "dynamic") || (word == "library")) {
 			word = "DECLARE-LIBRARY";
+		} else if (word == "chr") {
+			word = "CHR$";
+		} else if (word == "str") {
+			word = "STR$";
+		} else if (word == "string") {
+			word = "STRING$";
+		} else if (word == "erdev") {
+			word = "ERDEV$";
+		} else if (word == "environ") {
+			word = "ENVIRON$";
+		} else if (word == "ioctl") {
+			word = "IOCTL$";
+		} else if (word == "input") {
+			word = "INPUT$";
+		} else if (word == "inkey") {
+			word = "INKEY$";
+		} else if (word == "lcase") {
+			word = "LCASE$";
+		} else if (word == "left") {
+			word = "LEFT$";
+		} else if (word == "right") {
+			word = "RIGHT$";
+		} else if (word == "mid") {
+			word = "MID$";
+		} else if (word == "ltrim") {
+			word = "LTRIM$";
+		} else if (word == "mkd") {
+			word = "MKD$";
+		} else if (word == "mkdmbf") {
+			word = "MKDMBF$";
+		} else if (word == "mki") {
+			word = "MKI$";
+		} else if (word == "mkl") {
+			word = "MKL$";
+		} else if (word == "mks") {
+			word = "MKS$";
+		} else if (word == "mksmbf") {
+			word = "MKSMBF$";
+		} else if (word == "oct") {
+			word = "OCT$";
+		} else if (word == "rtrim") {
+			word = "RTRIM$";
+		} else if (word == "time") {
+			word = "TIME$";
+		} else if (word == "ucase") {
+			word = "UCASE$";
+		} else if (word == "varptr") {
+			word = "VARPTR$";
+		} else if (word == "_cwd") {
+			word = "_CWD$";
+		} else if (word == "_deflate") {
+			word = "_DEFLATE$";
+		} else if (word == "_device") {
+			word = "_DEVICE$";
+		} else if (word == "_dir") {
+			word = "_DIR$";
+		} else if (word == "_errormessage") {
+			word = "_ERRORMESSAGE$";
+		} else if (word == "_inclerrorfile") {
+			word = "_INCLERRORFILE$";
+		} else if (word == "_inflate") {
+			word = "_INFLATE$";
+		} else if (word == "_os") {
+			word = "_OS$";
+		} else if (word == "_title") {
+			word = "_TITLE$";
+		} else if (word == "_trim") {
+			word = "_TRIM$";
 		}
 		// logFunctions.writeLine(`After Before: ${word}`, this.outputChannnel);
 		return word;


### PR DESCRIPTION
## New `helpify` words:

- `CHR$`
- `STR$`
- `STRING$`
- `ERDEV$`
- `ENVIRON$`
- `IOCTL$`
- `INPUT$`
- `INKEY$`
- `LCASE$`
- `LEFT$`
- `RIGHT$`
- `MID$`
- `LTRIM$`
- `MKD$`
- `MKDMBF$`
- `MKI$`
- `MKL$`
- `MKS$`
- `MKSMBF$`
- `OCT$`
- `RTRIM$`
- `TIME$`
- `UCASE$`
- `VARPTR$`
- `_CWD$`
- `_DEFLATE$`
- `_DEVICE$`
- `_DIR$`
- `_ERRORMESSAGE$`
- `_INCLERRORFILE$`
- `_INFLATE$`
- `_OS$`
- `_TITLE$`
- `_TRIM$`
