### PR TITLE
hoverProvider link open fix

### DIFF
--- a/src/TokenInfo.ts
+++ b/src/TokenInfo.ts
@@ -104,7 +104,12 @@ export class TokenInfo {
 		let retvalue = ""
 		if (this.isKeyword) {
 			if (this.offlinehelp.length > 0) {
-				retvalue = fs.readFileSync(this.offlinehelp).toString();
+				const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("qb64")
+				const path = require('path');		
+				let helpPath: string = config.get("helpPath");
+				retvalue = fs.readFileSync(this.offlinehelp).toString();		
+				var linkified = retvalue.replaceAll(/\[(\w*)\]\((\w*)\)/igm, '[$1](file:' + helpPath.replaceAll('\\', '/') + '/$1.md)');
+				retvalue = linkified;
 			} else {
 				retvalue = "Press F1 for help"
 			}

--- a/src/TokenInfo.ts
+++ b/src/TokenInfo.ts
@@ -105,7 +105,6 @@ export class TokenInfo {
 		if (this.isKeyword) {
 			if (this.offlinehelp.length > 0) {
 				const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("qb64")
-				const path = require('path');		
 				let helpPath: string = config.get("helpPath");
 				retvalue = fs.readFileSync(this.offlinehelp).toString();		
 				var linkified = retvalue.replaceAll(/\[(\w*)\]\((\w*)\)/igm, '[$1](file:' + helpPath.replaceAll('\\', '/') + '/$1.md)');

--- a/src/TokenInfo.ts
+++ b/src/TokenInfo.ts
@@ -164,6 +164,74 @@ export class TokenInfo {
 			word = "DO...LOOP"
 		} else if (word == "declare" || (word == "dynamic") || (word == "library")) {
 			word = "DECLARE-LIBRARY";
+		} else if (word == "chr") {
+			word = "CHR$";
+		} else if (word == "str") {
+			word = "STR$";
+		} else if (word == "string") {
+			word = "STRING$";
+		} else if (word == "erdev") {
+			word = "ERDEV$";
+		} else if (word == "environ") {
+			word = "ENVIRON$";
+		} else if (word == "ioctl") {
+			word = "IOCTL$";
+		} else if (word == "input") {
+			word = "INPUT$";
+		} else if (word == "inkey") {
+			word = "INKEY$";
+		} else if (word == "lcase") {
+			word = "LCASE$";
+		} else if (word == "left") {
+			word = "LEFT$";
+		} else if (word == "right") {
+			word = "RIGHT$";
+		} else if (word == "mid") {
+			word = "MID$";
+		} else if (word == "ltrim") {
+			word = "LTRIM$";
+		} else if (word == "mkd") {
+			word = "MKD$";
+		} else if (word == "mkdmbf") {
+			word = "MKDMBF$";
+		} else if (word == "mki") {
+			word = "MKI$";
+		} else if (word == "mkl") {
+			word = "MKL$";
+		} else if (word == "mks") {
+			word = "MKS$";
+		} else if (word == "mksmbf") {
+			word = "MKSMBF$";
+		} else if (word == "oct") {
+			word = "OCT$";
+		} else if (word == "rtrim") {
+			word = "RTRIM$";
+		} else if (word == "time") {
+			word = "TIME$";
+		} else if (word == "ucase") {
+			word = "UCASE$";
+		} else if (word == "varptr") {
+			word = "VARPTR$";
+		} else if (word == "_cwd") {
+			word = "_CWD$";
+		} else if (word == "_deflate") {
+			word = "_DEFLATE$";
+		} else if (word == "_device") {
+			word = "_DEVICE$";
+		} else if (word == "_dir") {
+			word = "_DIR$";
+		} else if (word == "_errormessage") {
+			word = "_ERRORMESSAGE$";
+		} else if (word == "_inclerrorfile") {
+			word = "_INCLERRORFILE$";
+		} else if (word == "_inflate") {
+			word = "_INFLATE$";
+		} else if (word == "_os") {
+			word = "_OS$";
+		} else if (word == "_title") {
+			word = "_TITLE$";
+		} else if (word == "_trim") {
+			word = "_TRIM$";
 		}
 		// logFunctions.writeLine(`After Before: ${word}`, this.outputChannnel);
 		return word;

--- a/src/providers/HoverProvider.ts
+++ b/src/providers/HoverProvider.ts
@@ -25,6 +25,7 @@ export class HoverProvider implements vscode.HoverProvider {
 			const keywordInfo = new TokenInfo(commonFunctions.getQB64WordFromDocument(document, position), document.lineAt(position.line).text, this.outputChannnel);
 			if (keywordInfo.offlinehelp.length > 0) {
 				const markdownString = new vscode.MarkdownString(keywordInfo.getHoverText());
+            	markdownString.isTrusted = true;
 				return new vscode.Hover(markdownString);
 			}
 			logFunctions.writeLine(`offline hover not found: ${keywordInfo.token}`, this.outputChannnel);


### PR DESCRIPTION
This fixes the hoverProvider links to open properly according to the `helpPath`.

By using this setting:
```json
    "workbench.editorAssociations": {
        "*.md": "vscode.markdown.preview.editor"
    }
```

You force the markdown editors when a MD file is opened, to use the preview mode. This is ideal for me.

Now when you hover over something, and click a link that is in the hover markdown, it should open in your editor (and in preview mode if you add the setting above).