### PR TITLE
Add support for CRLF

### DIFF
--- a/syntaxes/qb64.tmLanguage.json
+++ b/syntaxes/qb64.tmLanguage.json
@@ -7,7 +7,7 @@
 	"comment": "Modified from the original ASP bundle. Originally modified by Thomas Aylott subtleGradient.com",
 	"patterns": [
 		{
-			"match": "\\n",
+			"match": "\\r?\\n",
 			"name": "meta.ending-space"
 		},
 		{
@@ -67,7 +67,7 @@
 					"name": "punctuation.definition.parameters.QB64"
 				}
 			},
-			"match": "^\\s*((?i:function|sub))\\s*([a-zA-Z_]\\w*)\\s*(\\()([^)]*)(\\)).*\\n?",
+			"match": "^\\s*((?i:function|sub))\\s*([a-zA-Z_]\\w*)\\s*(\\()([^)]*)(\\)).*\\r?\\n?",
 			"name": "meta.function.QB64"
 		},
 		{
@@ -94,7 +94,7 @@
 							"name": "punctuation.definition.comment.QB64"
 						}
 					},
-					"end": "\\n",
+					"end": "\\r?\\n",
 					"name": "comment.line.apostrophe.QB64"
 				}
 			]


### PR DESCRIPTION
Currently, the grammar for this project is being use on GitHub and I noticed that some files were getting the annoying red `^M` at the end of almost each lines. 
eg.: https://github.com/mbartolo2018/QB64/blob/main/untitled(2).bas
![image](https://github.com/user-attachments/assets/0bd0f074-6b55-425b-810c-36024fa5eed2)

This seems to be caused by the fact that the syntax here only considers LF (\n) line endings while some QuickBASIC code sometimes uses CRLF (\r\n) line endings. To hopefully solve this, I've added support for CRLF by adding the optional match `\r?` where `\n` was present in the grammar.